### PR TITLE
Updated packtpub url to get free books

### DIFF
--- a/packtpub_free_learning_ebook.rb
+++ b/packtpub_free_learning_ebook.rb
@@ -28,7 +28,7 @@ loggedin_page = page.form_with(:id => 'packt-user-login-form') do |form|
 end.submit
 
 begin
-	link = page.link_with(:href => /freelearning-claim/)		
+	link = page.link_with(:href => "/packt/offers/free-learning")
 	page = link.click
 rescue
 	abort("A problem occured simulating the click")


### PR DESCRIPTION
Packtpub url has changed.
Here is an updated url that works.